### PR TITLE
Rename and update Windows group one URLs and names

### DIFF
--- a/src/lambda_function.py
+++ b/src/lambda_function.py
@@ -18,7 +18,7 @@ def lambda_handler(event, context):
     MAC_GROUP_URL = "https://usea1-001-mssp.sentinelone.net/web/api/v2.1/update/agent/packages?osTypes=macos&sortBy=version&sortOrder=desc&status=ga"
 
     """NEW LINKS REQUESTED BY MITS"""
-    WINDOWS_GROUP_ONE_X86_URL = "https://usea1-001-mssp.sentinelone.net/web/api/v2.1/update/agent/packages?fileExtension=.msi&limit=1&osArches=64%20bit&osTypes=windows&skip=1&sortBy=version&sortOrder=desc&status=ga"
+    WINDOWS_GROUP_ONE_X64_URL = "https://usea1-001-mssp.sentinelone.net/web/api/v2.1/update/agent/packages?fileExtension=.msi&limit=1&osArches=64%20bit&osTypes=windows&skip=1&sortBy=version&sortOrder=desc&status=ga"
     WINDOWS_GROUP_ONE_ARM_URL = "https://usea1-001-mssp.sentinelone.net/web/api/v2.1/update/agent/packages?limit=1&osArches=ARM64&platformType=windows&skip=1&sortBy=version&sortOrder=desc&status=ga"
 
     WINDOWS_GROUP_ONE_NAME = "SentinelInstaller_windows_32bit_MSI_Latest_Group1.msi"
@@ -26,7 +26,7 @@ def lambda_handler(event, context):
     MAC_GROUP_NAME = "SentinelInstaller_macos_Latest.pkg"
 
     """NAME FOR THE NEW URLS"""
-    WINDOWS_GROUP_ONE_X86_NAME = "SentinelInstaller_windows_x86_Latest.msi"
+    WINDOWS_GROUP_ONE_X64_NAME = "SentinelInstaller_windows_x64_Latest.msi"
     WINDOWS_GROUP_ONE_ARM_NAME = "SentinelInstaller_windows_ARM_Latest.exe"
 
     print("I\'m running")
@@ -54,9 +54,9 @@ def lambda_handler(event, context):
             Filename=mac_group_file, Key=f"s1/{MAC_GROUP_NAME}", Bucket="s1-rsmd-installers")
 
         """FILE FOR THE NEW URLS"""
-        windows_group_one_X86_file = os.path.join(
+        windows_group_one_X64_file = os.path.join(
             DOWNLOAD_DIR, WINDOWS_GROUP_ONE_X86_NAME)
-        download_file(WINDOWS_GROUP_ONE_X86_URL, windows_group_one_X86_file)
+        download_file(WINDOWS_GROUP_ONE_X86_URL, windows_group_one_X64_file)
         windows_group_one_ARM_file = os.path.join(
             DOWNLOAD_DIR, WINDOWS_GROUP_ONE_ARM_NAME)
         download_file(WINDOWS_GROUP_ONE_ARM_URL, windows_group_one_ARM_file)


### PR DESCRIPTION
Update some links name to avoid confusions.